### PR TITLE
refactor: Remove unused imports

### DIFF
--- a/epsilon_transformers/analysis/activation_analysis.py
+++ b/epsilon_transformers/analysis/activation_analysis.py
@@ -1,14 +1,12 @@
-from typing import Iterator, List, Tuple, Dict
-from sklearn.linear_model import LinearRegression # type: ignore
-from transformer_lens import HookedTransformer # type: ignore
+from typing import List, Tuple, Dict
+from sklearn.linear_model import LinearRegression  # type: ignore
+from transformer_lens import HookedTransformer  # type: ignore
 from jaxtyping import Float
 import numpy as np
 import torch
 
-from epsilon_transformers.process.MixedStateTree import MixedStateTree
 from epsilon_transformers.process.Process import Process
 from epsilon_transformers.process.processes import ZeroOneR
-from epsilon_transformers.training.configs.training_configs import ProcessDatasetConfig
 
 # TODO: TQDM find_msp_subpace_in_residual_stream
 # TODO: (??) _generate_belief_state_and_activation() (??)
@@ -25,28 +23,42 @@ from epsilon_transformers.training.configs.training_configs import ProcessDatase
 
 
 def get_beliefs_for_transformer_inputs(
-    transformer_inputs: Float[torch.Tensor, "batch n_ctx"], 
-    msp_belief_index: Dict[Tuple[float, ...], int], 
-    tree_paths: List[List[int]], 
-    tree_beliefs: List[List[float]]
-) -> Tuple[Float[torch.Tensor, "batch n_ctx belief_dim"], Float[torch.Tensor, "batch n_ctx"]]:
+    transformer_inputs: Float[torch.Tensor, "batch n_ctx"],
+    msp_belief_index: Dict[Tuple[float, ...], int],
+    tree_paths: List[List[int]],
+    tree_beliefs: List[List[float]],
+) -> Tuple[
+    Float[torch.Tensor, "batch n_ctx belief_dim"], Float[torch.Tensor, "batch n_ctx"]
+]:
     batch, n_ctx = transformer_inputs.shape
     belief_dim = len(list(msp_belief_index.keys())[0])
-    path_belief_dict = {tuple(path): belief for path, belief in zip(tree_paths, tree_beliefs)}
+    path_belief_dict = {
+        tuple(path): belief for path, belief in zip(tree_paths, tree_beliefs)
+    }
     X_beliefs = torch.zeros(batch, n_ctx, belief_dim, device=transformer_inputs.device)
-    X_belief_indices = torch.zeros(batch, n_ctx, dtype=torch.int, device=transformer_inputs.device)
-    
+    X_belief_indices = torch.zeros(
+        batch, n_ctx, dtype=torch.int, device=transformer_inputs.device
+    )
+
     for i in range(batch):
         for j in range(n_ctx):
-            input_substring = transformer_inputs[i, :j+1].cpu().numpy()
+            input_substring = transformer_inputs[i, : j + 1].cpu().numpy()
             belief_state = path_belief_dict[tuple(input_substring)]
             belief_state = np.round(belief_state, 5)
-            X_beliefs[i, j] = torch.tensor(belief_state, dtype=torch.float32, device=transformer_inputs.device)
+            X_beliefs[i, j] = torch.tensor(
+                belief_state, dtype=torch.float32, device=transformer_inputs.device
+            )
             X_belief_indices[i, j] = msp_belief_index[tuple(belief_state)]
-    
+
     return X_beliefs, X_belief_indices
 
-def generate_belief_state_and_activations(model: HookedTransformer, process: Process, num_sequences: int) -> Tuple[Float[np.ndarray, "num_samples n_ctx num_states"], Float[np.ndarray, "num_samples n_ctx d_model"]]:
+
+def generate_belief_state_and_activations(
+    model: HookedTransformer, process: Process, num_sequences: int
+) -> Tuple[
+    Float[np.ndarray, "num_samples n_ctx num_states"],
+    Float[np.ndarray, "num_samples n_ctx d_model"],
+]:
     device = torch.device(
         "mps"
         if torch.backends.mps.is_available()
@@ -54,37 +66,56 @@ def generate_belief_state_and_activations(model: HookedTransformer, process: Pro
     )
 
     # Create the Mixed State Presentation Tree
-    msp_tree = process.derive_mixed_state_presentation(depth=model.cfg.n_ctx + 1) # For really large models this should definately be parallelized
-    
+    msp_tree = process.derive_mixed_state_presentation(
+        depth=model.cfg.n_ctx + 1
+    )  # For really large models this should definately be parallelized
+
     belief_states = []
     activations = []
-    for x in process.yield_emission_histories(sequence_len=model.cfg.n_ctx, num_sequences=num_sequences):
+    for x in process.yield_emission_histories(
+        sequence_len=model.cfg.n_ctx, num_sequences=num_sequences
+    ):
         belief_states.append(msp_tree.path_to_beliefs(x))
         _, cache = model.run_with_cache(torch.tensor([x], device=device))
-        activations.append(cache['ln_final.hook_normalized'].squeeze(0).cpu())
-    
+        activations.append(cache["ln_final.hook_normalized"].squeeze(0).cpu())
+
     # Turn into tensors
     belief_states_tensor = np.stack(belief_states)
     activations_tensor = np.array(activations)
 
     return belief_states_tensor, activations_tensor
 
-def find_msp_subspace_in_residual_stream(model: HookedTransformer, process: Process, num_sequences: int) -> Tuple[Float[np.ndarray, "num_tokens num_states"], Float[np.ndarray, "num_tokens num_states"]]:
-    ground_truth_belief_states, activations = generate_belief_state_and_activations(model=model, process=process, num_sequences=num_sequences)
+
+def find_msp_subspace_in_residual_stream(
+    model: HookedTransformer, process: Process, num_sequences: int
+) -> Tuple[
+    Float[np.ndarray, "num_tokens num_states"],
+    Float[np.ndarray, "num_tokens num_states"],
+]:
+    ground_truth_belief_states, activations = generate_belief_state_and_activations(
+        model=model, process=process, num_sequences=num_sequences
+    )
 
     # Reshape activations
-    ground_truth_belief_states_reshaped = ground_truth_belief_states.reshape(-1, ground_truth_belief_states.shape[-1])
+    ground_truth_belief_states_reshaped = ground_truth_belief_states.reshape(
+        -1, ground_truth_belief_states.shape[-1]
+    )
     activations_reshaped = activations.reshape(-1, activations.shape[-1])
-    
+
     # Run Linear Regression
-    reg = LinearRegression().fit(activations_reshaped, ground_truth_belief_states_reshaped)
+    reg = LinearRegression().fit(
+        activations_reshaped, ground_truth_belief_states_reshaped
+    )
     predicted_beliefs = reg.predict(activations_reshaped)
-    
+
     return ground_truth_belief_states_reshaped, predicted_beliefs
 
+
 if __name__ == "__main__":
-    model = HookedTransformer.from_pretrained('pythia-160m')
+    model = HookedTransformer.from_pretrained("pythia-160m")
     process = ZeroOneR()
     num_samples = 12
 
-    find_msp_subspace_in_residual_stream(model = model, process=process, num_sequences=num_samples)
+    find_msp_subspace_in_residual_stream(
+        model=model, process=process, num_sequences=num_samples
+    )

--- a/epsilon_transformers/analysis/entropy_analysis.py
+++ b/epsilon_transformers/analysis/entropy_analysis.py
@@ -1,8 +1,7 @@
 import numpy as np
-from typing import List, Tuple
+from typing import List
 from collections import Counter
-import matplotlib.pyplot as plt
-from scipy.optimize import minimize_scalar # type: ignore
+from scipy.optimize import minimize_scalar  # type: ignore
 
 
 def compute_block_entropy(sequence: List[int], max_block_length: int) -> np.ndarray:

--- a/epsilon_transformers/analysis/error_analysis.py
+++ b/epsilon_transformers/analysis/error_analysis.py
@@ -1,5 +1,4 @@
-from scipy.optimize import minimize_scalar # type: ignore
-from typing import List
+from scipy.optimize import minimize_scalar  # type: ignore
 import numpy as np
 
 # TODO: Check w/ Adam on which of these to keep

--- a/epsilon_transformers/nn/simple_transformer.py
+++ b/epsilon_transformers/nn/simple_transformer.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 class Head(nn.Module):
     def __init__(self, input_size, d_model, d_head):
         super().__init__()

--- a/epsilon_transformers/persistence.py
+++ b/epsilon_transformers/persistence.py
@@ -3,8 +3,8 @@ from io import BytesIO
 import os
 import pathlib
 import re
-from botocore.exceptions import ClientError # type: ignore
-import boto3 #type: ignore
+from botocore.exceptions import ClientError  # type: ignore
+import boto3  # type: ignore
 import dotenv
 import torch
 from typing import Dict, List, OrderedDict, Tuple, TypeVar
@@ -32,28 +32,27 @@ TorchModule = TypeVar("TorchModule", bound=torch.nn.modules.Module)
 # TODO: Add a check to _HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY to make sure every key is visited (??)
 # TODO: Generalize _state_dict_to_model_config into it's own base class so that it can handle different kinds of model classes
 
+
 class Persister(ABC):
     collection_location: pathlib.Path | str
 
     @abstractmethod
-    def save_model(self, model: TorchModule, num_tokens_trained: int):
-        ...
-    
+    def save_model(self, model: TorchModule, num_tokens_trained: int): ...
+
     @abstractmethod
-    def load_model(self, model_class: TorchModule, object_name: str) -> TorchModule:
-        ...
-    
+    def load_model(self, model_class: TorchModule, object_name: str) -> TorchModule: ...
+
     @abstractmethod
-    def _save_overwrite_protection(self, object_name: pathlib.Path | str):
-        ...
+    def _save_overwrite_protection(self, object_name: pathlib.Path | str): ...
+
 
 class LocalPersister(Persister):
     def __init__(self, collection_location: pathlib.Path):
         assert collection_location.is_dir()
         assert collection_location.exists()
-        self.collection_location: pathlib.Path = collection_location        
+        self.collection_location: pathlib.Path = collection_location
 
-    def _save_overwrite_protection(self, object_name: pathlib.Path): # type: ignore[override]
+    def _save_overwrite_protection(self, object_name: pathlib.Path):  # type: ignore[override]
         if object_name.exists():
             raise ValueError(f"Overwrite Protection: {object_name} already exists.")
 
@@ -70,34 +69,39 @@ class LocalPersister(Persister):
         model.load_state_dict(state_dict=state_dict)
         return model
 
+
 class S3Persister(Persister):
     def __init__(self, collection_location: str):
         dotenv.load_dotenv()
-        assert os.environ.get('AWS_ACCESS_KEY_ID') is not None
-        assert os.environ.get('AWS_SECRET_ACCESS_KEY') is not None
-        
-        self.s3 = boto3.client('s3')
-        buckets = [x['Name'] for x in self.s3.list_buckets()['Buckets']]
+        assert os.environ.get("AWS_ACCESS_KEY_ID") is not None
+        assert os.environ.get("AWS_SECRET_ACCESS_KEY") is not None
+
+        self.s3 = boto3.client("s3")
+        buckets = [x["Name"] for x in self.s3.list_buckets()["Buckets"]]
         if collection_location not in buckets:
-            raise ValueError(f"{collection_location} is not an existing bucket. Either use one of the existing buckets or create a new bucket")
+            raise ValueError(
+                f"{collection_location} is not an existing bucket. Either use one of the existing buckets or create a new bucket"
+            )
         self.collection_location: str = collection_location
 
-    def _save_overwrite_protection(self, object_name: str): # type: ignore[override]
+    def _save_overwrite_protection(self, object_name: str):  # type: ignore[override]
         try:
             self.s3.head_object(Bucket=self.collection_location, Key=object_name)
-            raise ValueError(f"Overwrite Protection: {self.collection_location}/{object_name} already exists")
+            raise ValueError(
+                f"Overwrite Protection: {self.collection_location}/{object_name} already exists"
+            )
         except ClientError as e:
-            if e.response['Error']['Code'] == '404':
+            if e.response["Error"]["Code"] == "404":
                 pass
             else:
                 raise ValueError(f"Expected 404 from empty object, received {e}")
 
     def save_model(self, model: TorchModule, num_tokens_trained: int):
-        object_name = f'{num_tokens_trained}.pt'
+        object_name = f"{num_tokens_trained}.pt"
         self._save_overwrite_protection(object_name=object_name)
-        
+
         print(f"Saving model as {object_name} in bucket {self.collection_location}")
-        
+
         buffer = BytesIO()
         torch.save(model.state_dict(), buffer)
         buffer.seek(0)
@@ -115,14 +119,23 @@ class S3Persister(Persister):
         download_buffer.seek(0)
         state_dict = torch.load(download_buffer)
 
-        train_config = self.load_json('train_config.json')
+        train_config = self.load_json("train_config.json")
         if train_config is not None:
             # TODO: refactor this
-            required_fields = ['d_vocab', 'd_model', 'n_ctx', 'd_head', 'n_heads', 'n_layers']
-            config_dict = {k: v for k, v in train_config.items() if k in required_fields}
-            config_dict['d_mlp'] = 4 * config_dict['d_model']
+            required_fields = [
+                "d_vocab",
+                "d_model",
+                "n_ctx",
+                "d_head",
+                "n_heads",
+                "n_layers",
+            ]
+            config_dict = {
+                k: v for k, v in train_config.items() if k in required_fields
+            }
+            config_dict["d_mlp"] = 4 * config_dict["d_model"]
             # change key n_heads to n_head
-            config_dict['n_head'] = config_dict.pop('n_heads')
+            config_dict["n_head"] = config_dict.pop("n_heads")
             config = RawModelConfig(**config_dict)
         else:
             print("No train_config.json found, inferring from state_dict")
@@ -131,49 +144,52 @@ class S3Persister(Persister):
         model = config.to_hooked_transformer(device=device)
         model.load_state_dict(state_dict=state_dict)
         return model
-    
+
     def list_objects(self) -> List[str]:
         objects = []
         continuation_token = None
 
         while True:
-            kwargs = {'Bucket': self.collection_location}
+            kwargs = {"Bucket": self.collection_location}
             if continuation_token:
-                kwargs['ContinuationToken'] = continuation_token
+                kwargs["ContinuationToken"] = continuation_token
 
             response = self.s3.list_objects_v2(**kwargs)
-            contents = response.get('Contents', [])
-            objects.extend([obj['Key'] for obj in contents])
+            contents = response.get("Contents", [])
+            objects.extend([obj["Key"] for obj in contents])
 
-            if 'NextContinuationToken' in response:
-                continuation_token = response['NextContinuationToken']
+            if "NextContinuationToken" in response:
+                continuation_token = response["NextContinuationToken"]
             else:
                 break
 
         return objects
-    
+
     def load_json(self, object_name: str) -> Dict:
         try:
             json_str = self.load_object(object_name)
             return json.loads(json_str)
         except ClientError as e:
-            if e.response['Error']['Code'] == 'NoSuchKey':
+            if e.response["Error"]["Code"] == "NoSuchKey":
                 return None
             else:
                 raise e
-    
+
     def load_object(self, object_name: str) -> str:
         download_buffer = BytesIO()
         self.s3.download_fileobj(self.collection_location, object_name, download_buffer)
         download_buffer.seek(0)
-        return download_buffer.read().decode('utf-8')
+        return download_buffer.read().decode("utf-8")
 
-def _state_dict_to_model_config(state_dict: OrderedDict, n_ctx: int = 10) -> RawModelConfig:
+
+def _state_dict_to_model_config(
+    state_dict: OrderedDict, n_ctx: int = 10
+) -> RawModelConfig:
     _HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY: Dict[str, List[Tuple[str, int]]] = {
-        r"embed\.W_E": [('d_vocab', 0), ('d_model', 1)],
+        r"embed\.W_E": [("d_vocab", 0), ("d_model", 1)],
         r"pos_embed\.W_pos": [],
         r"blocks\.\d+\.ln\d+\.(w|b)": [],
-        r"blocks\.\d+\.attn\.W_Q": [('n_head', 0), ('d_head', 2)],
+        r"blocks\.\d+\.attn\.W_Q": [("n_head", 0), ("d_head", 2)],
         r"blocks\.\d+\.attn\.b_Q": [],
         r"blocks\.\d+\.attn\.W_K": [],
         r"blocks\.\d+\.attn\.b_K": [],
@@ -183,43 +199,62 @@ def _state_dict_to_model_config(state_dict: OrderedDict, n_ctx: int = 10) -> Raw
         r"blocks\.\d+\.attn\.b_V": [],
         r"blocks\.\d+\.attn\.mask": [],
         r"blocks\.\d+\.attn\.IGNORE": [],
-        r"blocks\.\d+\.mlp\.W_in": [('d_mlp', 1)],
+        r"blocks\.\d+\.mlp\.W_in": [("d_mlp", 1)],
         r"blocks\.\d+\.mlp\.b_in": [],
         r"blocks\.\d+\.mlp\.W_out": [],
         r"blocks\.\d+\.mlp\.b_out": [],
         r"ln_final\.(w|b)": [],
-        r"unembed\.(W_U|b_U)": []
+        r"unembed\.(W_U|b_U)": [],
     }
+
     def _extract_true_key(dictionary: Dict[str, bool]) -> str:
         out = []
         for key, value in dictionary.items():
             if value:
                 out.append(key)
-        assert len(out) == 1,  f"{out} does not fit one of the expected module regexs: {_HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY}"
+        assert (
+            len(out) == 1
+        ), f"{out} does not fit one of the expected module regexs: {_HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY}"
         return out[0]
+
     def _extract_n_layers(state_dict: OrderedDict) -> int:
         highest_block_idx = None
         for key in state_dict.keys():
             if not bool(re.match(r"blocks\.\d+\.", key)):
                 continue
-            local_block_idx = int(re.search(r'\d+', key).group())
+            local_block_idx = int(re.search(r"\d+", key).group())
             if highest_block_idx is None:
                 highest_block_idx = local_block_idx
             elif local_block_idx > highest_block_idx:
                 highest_block_idx = local_block_idx
         return highest_block_idx + 1
 
-    param_dict = dict(d_vocab=None, d_model=None, n_ctx=n_ctx, d_head=None, n_head=None, d_mlp=None, n_layers=_extract_n_layers(state_dict=state_dict))
+    param_dict = dict(
+        d_vocab=None,
+        d_model=None,
+        n_ctx=n_ctx,
+        d_head=None,
+        n_head=None,
+        d_mlp=None,
+        n_layers=_extract_n_layers(state_dict=state_dict),
+    )
     for module_name, module in state_dict.items():
-        regex_dict = {pattern: bool(re.match(pattern, module_name)) for pattern in _HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY.keys()}
+        regex_dict = {
+            pattern: bool(re.match(pattern, module_name))
+            for pattern in _HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY.keys()
+        }
         pattern = _extract_true_key(regex_dict)
         for key, dim in _HOOKED_TRANSFORMER_MODULE_REGEXES_REGISTRY[pattern]:
             if param_dict[key] is None:
                 param_dict[key] = module.size()[dim]
     assert all([value is not None for value in param_dict.values()])
-    return RawModelConfig(**param_dict) # type: ignore[arg-type]
+    return RawModelConfig(**param_dict)  # type: ignore[arg-type]
+
 
 if __name__ == "__main__":
-    from transformer_lens import HookedTransformer # type: ignore
+    from transformer_lens import HookedTransformer  # type: ignore
+
     persister = S3Persister(collection_location="mess3-param-change")
-    model: HookedTransformer = persister.load_model(device=torch.device('cpu'), object_name='4800000.pt')
+    model: HookedTransformer = persister.load_model(
+        device=torch.device("cpu"), object_name="4800000.pt"
+    )

--- a/epsilon_transformers/process/MixedStateTree.py
+++ b/epsilon_transformers/process/MixedStateTree.py
@@ -1,137 +1,185 @@
-from multiprocessing.util import sub_debug
 from jaxtyping import Float
 from typing import List, Set, Tuple
 import numpy as np
 from collections import deque
-from scipy.stats import entropy # type: ignore
+from scipy.stats import entropy  # type: ignore
 
 
 # TODO: Move the derive MSP function to be in the MSP init
 # TODO: Add
 
+
 class MixedStateTreeNode:
-	state_prob_vector: Float[np.ndarray, "n_states"]
-	path: List[int]
-	children: Set['MixedStateTreeNode']
-	emission_prob: float
-	
-	def __init__(self, state_prob_vector: Float[np.ndarray, "n_states"], children: Set['MixedStateTreeNode'], path: List[int], emission_prob: float):
-		self.state_prob_vector = state_prob_vector
-		self.path = path
-		self.children = children
-		self.emission_prob = emission_prob
-	
-	def add_child(self, child: 'MixedStateTreeNode'):
-		self.children.add(child)
+    state_prob_vector: Float[np.ndarray, "n_states"]
+    path: List[int]
+    children: Set["MixedStateTreeNode"]
+    emission_prob: float
+
+    def __init__(
+        self,
+        state_prob_vector: Float[np.ndarray, "n_states"],
+        children: Set["MixedStateTreeNode"],
+        path: List[int],
+        emission_prob: float,
+    ):
+        self.state_prob_vector = state_prob_vector
+        self.path = path
+        self.children = children
+        self.emission_prob = emission_prob
+
+    def add_child(self, child: "MixedStateTreeNode"):
+        self.children.add(child)
+
 
 class MixedStateTree:
-	root_node: MixedStateTreeNode
-	process: str
-	depth: int
-	nodes: Set[MixedStateTreeNode]
+    root_node: MixedStateTreeNode
+    process: str
+    depth: int
+    nodes: Set[MixedStateTreeNode]
 
-	@property
-	def belief_states(self) -> List[Float[np.ndarray, "num_states"]]:
-		return [x.state_prob_vector for x in self.nodes]
-	
-	@property
-	def paths(self) -> List[List[int]]:
-		return [x.path for x in self.nodes]
-	
-	@property
-	def paths_and_belief_states(self) -> Tuple[List[List[int]], Float[np.ndarray, "n_states"]]:
-		paths_and_beliefs = [(x.path, x.state_prob_vector) for x in self.nodes]
-		paths = [x[0] for x in paths_and_beliefs]
-		beliefs = [x[1] for x in paths_and_beliefs]
-		return paths, beliefs
-	
-	@property
-	def block_entropy(self) -> Float[np.ndarray, "depth"]:
-		depth_emission_probs = self._traverse(node=self.root_node, depth=0, accumulated_prob=1.0)
-		block_entropy = np.array([entropy(probs) if probs else 0 for probs in depth_emission_probs])
-		return block_entropy
+    @property
+    def belief_states(self) -> List[Float[np.ndarray, "num_states"]]:
+        return [x.state_prob_vector for x in self.nodes]
 
-	@property
-	def myopic_entropy(self) -> Float[np.ndarray, "depth-1"]:
-		return np.diff(self.block_entropy)
-	
-	def __init__(self, root_node: MixedStateTreeNode, process: str, nodes: Set[MixedStateTreeNode], depth: int):
-		self.root_node = root_node
-		self.process = process
-		self.nodes = nodes
-		self.depth = depth
+    @property
+    def paths(self) -> List[List[int]]:
+        return [x.path for x in self.nodes]
 
-	def _traverse(self, node: MixedStateTreeNode, depth: int, accumulated_prob: float) -> List[List[float]]:
-		stack = deque([(node, depth, accumulated_prob)])
-		depth_emission_probs: List[List[float]] = [[] for _ in range(self.depth)]
-    
-		while stack:
-			node, depth, accumulated_prob = stack.pop()
-			if depth < self.depth:
-				if node is not self.root_node:
-					depth_emission_probs[depth].append(accumulated_prob * node.emission_prob)
-				for child in node.children:
-					stack.append((child, depth + 1, accumulated_prob * node.emission_prob if node is not self.root_node else 1.0))
-		
-		return depth_emission_probs
+    @property
+    def paths_and_belief_states(
+        self,
+    ) -> Tuple[List[List[int]], Float[np.ndarray, "n_states"]]:
+        paths_and_beliefs = [(x.path, x.state_prob_vector) for x in self.nodes]
+        paths = [x[0] for x in paths_and_beliefs]
+        beliefs = [x[1] for x in paths_and_beliefs]
+        return paths, beliefs
 
-	def path_to_beliefs(self, path: List[int]) -> Float[np.ndarray, "path_length n_states"]:
-		assert len(path) <= self.depth, f"path length: {len(path)} is too long . Tree has depth of {self.depth}"
+    @property
+    def block_entropy(self) -> Float[np.ndarray, "depth"]:
+        depth_emission_probs = self._traverse(
+            node=self.root_node, depth=0, accumulated_prob=1.0
+        )
+        block_entropy = np.array(
+            [entropy(probs) if probs else 0 for probs in depth_emission_probs]
+        )
+        return block_entropy
 
-		belief_states = []
-		current_node = self.root_node
-		for i in range(len(path)):
-			sub_path = path[:i + 1]
-			for child in current_node.children:
-				if child.path == sub_path:
-					belief_states.append(child.state_prob_vector)
-					current_node = child
-					break
+    @property
+    def myopic_entropy(self) -> Float[np.ndarray, "depth-1"]:
+        return np.diff(self.block_entropy)
 
-		assert current_node.path == path, f"{path} is not a valid path for this process"
-		assert len(belief_states) == len(path)
-		return np.stack(belief_states)
-	
+    def __init__(
+        self,
+        root_node: MixedStateTreeNode,
+        process: str,
+        nodes: Set[MixedStateTreeNode],
+        depth: int,
+    ):
+        self.root_node = root_node
+        self.process = process
+        self.nodes = nodes
+        self.depth = depth
 
-	def build_msp_transition_matrix(self) -> Float[np.ndarray, "num_emission num_msp_nodes num_msp_nodes"]:
-		seen_prob_vectors = {}
-		max_state_index = -1  # To keep track of the last index assigned to a unique state
-		queue = deque([(self.root_node, None, -1, 0)])  # (node, emitted_symbol, parent_state_index, emission_prob)
-		# get the number of symbols by looking at all entries of all paths and finding the max index
-		num_symbols = len(np.unique(np.concatenate([np.unique(x) for x in self.paths])))
-		num_nodes = len(self.nodes)
-		
-		# Assuming we know the number of symbols and maximum states to expect
-		M = np.zeros((num_symbols, num_nodes, num_nodes))  # Adjust size appropriately
+    def _traverse(
+        self, node: MixedStateTreeNode, depth: int, accumulated_prob: float
+    ) -> List[List[float]]:
+        stack = deque([(node, depth, accumulated_prob)])
+        depth_emission_probs: List[List[float]] = [[] for _ in range(self.depth)]
 
-		while queue:
-			current_node, emitted_symbol, from_state_index, emission_prob = queue.popleft()
-			rounded_vector = np.around(current_node.state_prob_vector, decimals=5)
-			vector_tuple = tuple(rounded_vector.tolist())
+        while stack:
+            node, depth, accumulated_prob = stack.pop()
+            if depth < self.depth:
+                if node is not self.root_node:
+                    depth_emission_probs[depth].append(
+                        accumulated_prob * node.emission_prob
+                    )
+                for child in node.children:
+                    stack.append(
+                        (
+                            child,
+                            depth + 1,
+                            (
+                                accumulated_prob * node.emission_prob
+                                if node is not self.root_node
+                                else 1.0
+                            ),
+                        )
+                    )
 
-			# Check if we've seen this state vector before
-			if vector_tuple not in seen_prob_vectors:
-				max_state_index += 1
-				seen_prob_vectors[vector_tuple] = max_state_index
-				to_state_index = max_state_index
-			else:
-				to_state_index = seen_prob_vectors[vector_tuple]
+        return depth_emission_probs
 
-			# Only add this if there's a valid symbol and from_state_index
-			if emitted_symbol is not None and from_state_index != -1:
-				M[emitted_symbol, from_state_index, to_state_index] = emission_prob
+    def path_to_beliefs(
+        self, path: List[int]
+    ) -> Float[np.ndarray, "path_length n_states"]:
+        assert (
+            len(path) <= self.depth
+        ), f"path length: {len(path)} is too long . Tree has depth of {self.depth}"
 
-			# Check and add children to the queue
-			for child in current_node.children:
-				if child.path:
-					child_symbol = child.path[-1]  # Assume last element of the path is the symbol
-					child_emission_prob = child.emission_prob
-					queue.append((child, child_symbol, to_state_index, child_emission_prob))
+        belief_states = []
+        current_node = self.root_node
+        for i in range(len(path)):
+            sub_path = path[: i + 1]
+            for child in current_node.children:
+                if child.path == sub_path:
+                    belief_states.append(child.state_prob_vector)
+                    current_node = child
+                    break
 
-		# delete entries that were never visited
-		M = M[:, :max_state_index + 1, :max_state_index + 1]
+        assert current_node.path == path, f"{path} is not a valid path for this process"
+        assert len(belief_states) == len(path)
+        return np.stack(belief_states)
 
-		return M
-	
-	def _get_nodes_at_depth(self, depth: int) -> Set[MixedStateTreeNode]:
-		return {n for n in self.nodes if len(n.path) == depth}
+    def build_msp_transition_matrix(
+        self,
+    ) -> Float[np.ndarray, "num_emission num_msp_nodes num_msp_nodes"]:
+        seen_prob_vectors = {}
+        max_state_index = (
+            -1
+        )  # To keep track of the last index assigned to a unique state
+        queue = deque(
+            [(self.root_node, None, -1, 0)]
+        )  # (node, emitted_symbol, parent_state_index, emission_prob)
+        # get the number of symbols by looking at all entries of all paths and finding the max index
+        num_symbols = len(np.unique(np.concatenate([np.unique(x) for x in self.paths])))
+        num_nodes = len(self.nodes)
+
+        # Assuming we know the number of symbols and maximum states to expect
+        M = np.zeros((num_symbols, num_nodes, num_nodes))  # Adjust size appropriately
+
+        while queue:
+            current_node, emitted_symbol, from_state_index, emission_prob = (
+                queue.popleft()
+            )
+            rounded_vector = np.around(current_node.state_prob_vector, decimals=5)
+            vector_tuple = tuple(rounded_vector.tolist())
+
+            # Check if we've seen this state vector before
+            if vector_tuple not in seen_prob_vectors:
+                max_state_index += 1
+                seen_prob_vectors[vector_tuple] = max_state_index
+                to_state_index = max_state_index
+            else:
+                to_state_index = seen_prob_vectors[vector_tuple]
+
+            # Only add this if there's a valid symbol and from_state_index
+            if emitted_symbol is not None and from_state_index != -1:
+                M[emitted_symbol, from_state_index, to_state_index] = emission_prob
+
+            # Check and add children to the queue
+            for child in current_node.children:
+                if child.path:
+                    child_symbol = child.path[
+                        -1
+                    ]  # Assume last element of the path is the symbol
+                    child_emission_prob = child.emission_prob
+                    queue.append(
+                        (child, child_symbol, to_state_index, child_emission_prob)
+                    )
+
+        # delete entries that were never visited
+        M = M[:, : max_state_index + 1, : max_state_index + 1]
+
+        return M
+
+    def _get_nodes_at_depth(self, depth: int) -> Set[MixedStateTreeNode]:
+        return {n for n in self.nodes if len(n.path) == depth}

--- a/epsilon_transformers/process/dataset.py
+++ b/epsilon_transformers/process/dataset.py
@@ -1,8 +1,7 @@
 import torch
-from itertools import islice
 from typing import Dict, Iterable, Tuple, List
 from jaxtyping import Float
-from torch.utils.data import IterableDataset, DataLoader
+from torch.utils.data import IterableDataset
 
 from epsilon_transformers.process.Process import Process
 from epsilon_transformers.process.processes import PROCESS_REGISTRY
@@ -20,7 +19,13 @@ class ProcessDataset(IterableDataset):
     sequence_length: int
     num_samples: int
 
-    def __init__(self, process_name: str, process_params: Dict[str, float], sequence_length: int, num_samples: int):
+    def __init__(
+        self,
+        process_name: str,
+        process_params: Dict[str, float],
+        sequence_length: int,
+        num_samples: int,
+    ):
         super(ProcessDataset).__init__()
 
         process_class = PROCESS_REGISTRY.get(process_name, None)

--- a/epsilon_transformers/process/processes.py
+++ b/epsilon_transformers/process/processes.py
@@ -11,6 +11,7 @@ from epsilon_transformers.process.Process import Process
 # TODO: Think through whether self.name is necessary (review it's usage in derive_mixed_state_presentation)
 # TODO: Move _create_hmm into the init function prior to super()__init__()
 
+
 class ZeroOneR(Process):
     def __init__(self, prob_of_zero_from_r_state: float = 0.5):
         self.name = "z1r"
@@ -74,12 +75,20 @@ class Mess3(Process):
 
         return T, state_names
 
+
 class TransitionMatrixProcess(Process):
     def __init__(self, transition_matrix: np.ndarray):
         self.transition_matrix = transition_matrix
         super().__init__()
 
     def _create_hmm(self):
-        return self.transition_matrix, {i: i for i in range(self.transition_matrix.shape[0])}
+        return self.transition_matrix, {
+            i: i for i in range(self.transition_matrix.shape[0])
+        }
 
-PROCESS_REGISTRY: Dict[str, type] = {key: value for key, value in inspect.currentframe().f_locals.items() if isinstance(value, type) and issubclass(value, Process) and key != 'Process'}
+
+PROCESS_REGISTRY: Dict[str, type] = {
+    key: value
+    for key, value in inspect.currentframe().f_locals.items()
+    if isinstance(value, type) and issubclass(value, Process) and key != "Process"
+}

--- a/epsilon_transformers/training/configs/base_config.py
+++ b/epsilon_transformers/training/configs/base_config.py
@@ -9,4 +9,3 @@ class Config(BaseModel, extra="forbid"):
         with open(config_path, "r") as file:
             config_data = yaml.safe_load(file)
         return cls(**config_data)
-

--- a/epsilon_transformers/training/configs/model_configs.py
+++ b/epsilon_transformers/training/configs/model_configs.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import torch
-from transformer_lens import HookedTransformer, HookedTransformerConfig # type: ignore
+from transformer_lens import HookedTransformer, HookedTransformerConfig  # type: ignore
 
 from epsilon_transformers.training.configs.base_config import Config
 
@@ -30,4 +30,3 @@ class RawModelConfig(Config):
             act_fn="relu",
         )
         return HookedTransformer(config)
-

--- a/epsilon_transformers/training/configs/training_configs.py
+++ b/epsilon_transformers/training/configs/training_configs.py
@@ -1,8 +1,6 @@
-from io import BytesIO
 from typing import Dict, Literal
-from pydantic import BaseModel, model_validator
+from pydantic import model_validator
 import pathlib
-import yaml
 import torch
 from torch.utils.data import DataLoader
 from typing import Union, Optional
@@ -140,9 +138,16 @@ class Log:
 
     def persist(self):
         if self.config.wandb:
-            wandb.log({k: v for k, v in asdict(self).items() if v is not None and not isinstance(v, LoggingConfig)})
+            wandb.log(
+                {
+                    k: v
+                    for k, v in asdict(self).items()
+                    if v is not None and not isinstance(v, LoggingConfig)
+                }
+            )
         if self.config.local is not None:
             raise NotImplementedError
+
 
 class LoggingConfig(Config):
     local: Optional[pathlib.Path] = None
@@ -174,13 +179,15 @@ class TrainConfig(Config):
     seed: int
     verbose: bool
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_model(self):
         dataset_process = self.dataset.process
         if dataset_process:
             process_vocab_len = PROCESS_REGISTRY[dataset_process]().vocab_len
             if self.model.d_vocab != process_vocab_len:
-                raise ValueError(f"Model's d_vocab ({self.model.d_vocab}) doesn't match dataset process's vocab_len ({process_vocab_len})")
+                raise ValueError(
+                    f"Model's d_vocab ({self.model.d_vocab}) doesn't match dataset process's vocab_len ({process_vocab_len})"
+                )
         return self
 
     def init_logger(self) -> Log:

--- a/epsilon_transformers/training/train.py
+++ b/epsilon_transformers/training/train.py
@@ -1,11 +1,11 @@
-import fire # type: ignore
+import fire  # type: ignore
 import pathlib
 import random
 import numpy as np
 import torch
 from tqdm import tqdm
 from torch.utils.data import DataLoader
-from transformer_lens import HookedTransformer # type: ignore
+from transformer_lens import HookedTransformer  # type: ignore
 
 from epsilon_transformers.persistence import Persister
 from epsilon_transformers.training.configs.training_configs import (
@@ -60,11 +60,12 @@ def _check_if_action_batch(
     perform_action_every_n_batches = perform_action_every_n_tokens // tokens_per_batch
     return (batch_idx + 1) % perform_action_every_n_batches == 0
 
+
 def _evaluate_model(
     model: HookedTransformer,
     eval_dataloader: DataLoader,
     device: torch.device,
-    log: Log
+    log: Log,
 ) -> Log:
     with torch.no_grad():
         for input_data, target_data in tqdm(eval_dataloader, desc="Eval Loop"):
@@ -87,19 +88,17 @@ def _evaluate_log_and_persist(
         sequence_length=model.cfg.n_ctx, train=False
     )
     _evaluate_model(
-        model=model,
-        eval_dataloader=eval_dataloader,
-        device=device,
-        log=log
+        model=model, eval_dataloader=eval_dataloader, device=device, log=log
     )
-    
+
     if verbose:
         print(f"This is the log\n{log}")
-    
+
     log.persist()
     log.reset()
     persister.save_model(model, tokens_trained)
     return log
+
 
 def train_model(config: TrainConfig) -> HookedTransformer:
     device = torch.device(
@@ -115,11 +114,13 @@ def train_model(config: TrainConfig) -> HookedTransformer:
     train_dataloader = config.dataset.to_dataloader(
         sequence_length=model.cfg.n_ctx, train=True
     )
-    
+
     persister = config.persistance.init()
     log = config.init_logger()
     model.train()
-    for batch_idx, (input_data, target_data) in enumerate(tqdm(train_dataloader, desc="Train Loop")):
+    for batch_idx, (input_data, target_data) in enumerate(
+        tqdm(train_dataloader, desc="Train Loop")
+    ):
         input_data, target_data = input_data.to(device), target_data.to(device)
         loss = model(input_data, return_type="loss")
         log.update_metrics(train_or_test="train", loss=loss.item())
@@ -171,6 +172,7 @@ def train_model(config: TrainConfig) -> HookedTransformer:
 def _main(config_path: pathlib.Path):
     config: TrainConfig = TrainConfig.from_yaml(config_path)
     train_model(config)
+
 
 if __name__ == "__main__":
     fire.Fire(_main)

--- a/epsilon_transformers/visualization/graph.py
+++ b/epsilon_transformers/visualization/graph.py
@@ -1,17 +1,15 @@
 import matplotlib.pyplot as plt
-import networkx as nx # type: ignore
+import networkx as nx  # type: ignore
 from epsilon_transformers.analysis.entropy_analysis import (
     compute_block_entropy,
     compute_conditional_entropy,
     compute_empirical_conditional_entropy,
 )
 from typing import List
-from matplotlib import colors
-import networkx as nx
-import matplotlib.pyplot as plt
 from typing import Optional, Dict
 import numpy as np
 from jaxtyping import Float
+
 
 def determine_layout(G, layout_type):
     """Determine the layout of the graph."""
@@ -270,8 +268,11 @@ def plot_empirical_conditional_entropy_diagram(
     plt.grid(True)
     plt.show()
 
-def transition_matrix_to_graph(transition_matrix: Float[np.ndarray, "vocab_len num_states num_states"],
-                               state_names: Optional[Dict[str, int]] = None) -> nx.DiGraph:
+
+def transition_matrix_to_graph(
+    transition_matrix: Float[np.ndarray, "vocab_len num_states num_states"],
+    state_names: Optional[Dict[str, int]] = None,
+) -> nx.DiGraph:
     """
     Convert a transition matrix to a graph.
 
@@ -308,6 +309,11 @@ def transition_matrix_to_graph(transition_matrix: Float[np.ndarray, "vocab_len n
                 if transition_matrix[i, j, k] != 0:
                     from_node = state_names[j] if state_names else j
                     to_node = state_names[k] if state_names else k
-                    G.add_edge(from_node, to_node, label=str(i), weight=transition_matrix[i, j, k])
+                    G.add_edge(
+                        from_node,
+                        to_node,
+                        label=str(i),
+                        weight=transition_matrix[i, j, k],
+                    )
 
     return G

--- a/epsilon_transformers/visualization/plots.py
+++ b/epsilon_transformers/visualization/plots.py
@@ -1,6 +1,6 @@
 from typing import Literal
-import datashader as ds # type: ignore
-import datashader.transfer_functions as tf # type: ignore
+import datashader as ds  # type: ignore
+import datashader.transfer_functions as tf  # type: ignore
 from matplotlib.figure import Figure
 import pandas as pd
 from PIL import Image
@@ -9,12 +9,15 @@ from matplotlib import pyplot as plt
 from jaxtyping import Float
 import torch
 
-from epsilon_transformers.analysis.activation_analysis import find_msp_subspace_in_residual_stream
+from epsilon_transformers.analysis.activation_analysis import (
+    find_msp_subspace_in_residual_stream,
+)
 from epsilon_transformers.process.processes import ZeroOneR
 from epsilon_transformers.training.configs.model_configs import RawModelConfig
 
 # TODO: TQDM plot_ground_truth_and_evaluated_2d_simplex
 # TODO: Modularize generate_belief_state_figures_datashader && parallalize slow tensor code
+
 
 def _project_to_simplex(points: Float[np.ndarray, "num_points num_states"]):
     """Project points onto the 2-simplex (equilateral triangle in 2D)."""
@@ -22,74 +25,142 @@ def _project_to_simplex(points: Float[np.ndarray, "num_points num_states"]):
     y = (np.sqrt(3) / 2) * points[:, 2]
     return x, y
 
-# Combine aggregated channels into RGB images
-def _combine_channels_to_rgb(agg_r, agg_g, agg_b, px:int):
-    img_r = tf.shade(agg_r, cmap=['black', 'red'], how='linear')
-    img_g = tf.shade(agg_g, cmap=['black', 'green'], how='linear')
-    img_b = tf.shade(agg_b, cmap=['black', 'blue'], how='linear')
 
-    img_r = tf.spread(img_r, px=px, shape='circle')
-    img_g = tf.spread(img_g, px=px, shape='circle')
-    img_b = tf.spread(img_b, px=px, shape='circle')
+# Combine aggregated channels into RGB images
+def _combine_channels_to_rgb(agg_r, agg_g, agg_b, px: int):
+    img_r = tf.shade(agg_r, cmap=["black", "red"], how="linear")
+    img_g = tf.shade(agg_g, cmap=["black", "green"], how="linear")
+    img_b = tf.shade(agg_b, cmap=["black", "blue"], how="linear")
+
+    img_r = tf.spread(img_r, px=px, shape="circle")
+    img_g = tf.spread(img_g, px=px, shape="circle")
+    img_b = tf.spread(img_b, px=px, shape="circle")
 
     # Combine using numpy
     r_array = np.array(img_r.to_pil()).astype(np.float64)
     g_array = np.array(img_g.to_pil()).astype(np.float64)
     b_array = np.array(img_b.to_pil()).astype(np.float64)
-    
+
     # Stack arrays into an RGB image (ignoring alpha channel for simplicity)
-    rgb_image = np.stack([r_array[:,:,0], g_array[:,:,1], b_array[:,:,2]], axis=-1)
-    
+    rgb_image = np.stack(
+        [r_array[:, :, 0], g_array[:, :, 1], b_array[:, :, 2]], axis=-1
+    )
+
     return Image.fromarray(np.uint8(rgb_image))
+
 
 # TODO: I changed up the code for this to something which makes sense to me (creating panda dataframes from ground truth and predicted simplex. Check to see if this is what should actually be done)
 def plot_ground_truth_and_evaluated_2d_simplex(
-    ground_truth_tensor: Float[np.ndarray, "num_points num_states"], 
-    predicted_beliefs: Float[np.ndarray, "num_points num_states"], 
+    ground_truth_tensor: Float[np.ndarray, "num_points num_states"],
+    predicted_beliefs: Float[np.ndarray, "num_points num_states"],
     plot_triangles: bool,
-    facecolor: Literal['black', 'white'],
-    px: int
+    facecolor: Literal["black", "white"],
+    px: int,
 ) -> Figure:
     # Projection and DataFrame preparation
     bs_x, bs_y = _project_to_simplex(np.array(ground_truth_tensor))
-    ground_truth_data_frame = pd.DataFrame({'x': bs_x, 'y': bs_y, 'r': ground_truth_tensor[:, 0], 'g': ground_truth_tensor[:, 1], 'b': ground_truth_tensor[:, 2]})
+    ground_truth_data_frame = pd.DataFrame(
+        {
+            "x": bs_x,
+            "y": bs_y,
+            "r": ground_truth_tensor[:, 0],
+            "g": ground_truth_tensor[:, 1],
+            "b": ground_truth_tensor[:, 2],
+        }
+    )
 
     pb_x, pb_y = _project_to_simplex(np.array(predicted_beliefs))
-    predicted_belief_vector_data_frame = pd.DataFrame({'x': pb_x, 'y': pb_y, 'r': predicted_beliefs[:, 0], 'g': predicted_beliefs[:, 1], 'b': predicted_beliefs[:, 2]})
+    predicted_belief_vector_data_frame = pd.DataFrame(
+        {
+            "x": pb_x,
+            "y": pb_y,
+            "r": predicted_beliefs[:, 0],
+            "g": predicted_beliefs[:, 1],
+            "b": predicted_beliefs[:, 2],
+        }
+    )
 
     # Create canvas
-    canvas = ds.Canvas(plot_width=1000, plot_height=1000, x_range=(-0.1, 1.1), y_range=(-0.1, np.sqrt(3)/2 + 0.1))
-    
-    # Aggregate each RGB channel separately for ground truth and predicted beliefs
-    colours = ['r', 'g', 'b']
-    ground_truth_aggregated = {color: canvas.points(ground_truth_data_frame, 'x', 'y', ds.mean(color)) for color in colours}
-    predited_belief_vector_aggregated = {color: canvas.points(predicted_belief_vector_data_frame, 'x', 'y', ds.mean(color)) for color in colours}
+    canvas = ds.Canvas(
+        plot_width=1000,
+        plot_height=1000,
+        x_range=(-0.1, 1.1),
+        y_range=(-0.1, np.sqrt(3) / 2 + 0.1),
+    )
 
-    img_gt = _combine_channels_to_rgb(ground_truth_aggregated['r'], ground_truth_aggregated['g'], ground_truth_aggregated['b'], px=px)
-    img_pb = _combine_channels_to_rgb(predited_belief_vector_aggregated['r'], predited_belief_vector_aggregated['g'], predited_belief_vector_aggregated['b'], px=px)
+    # Aggregate each RGB channel separately for ground truth and predicted beliefs
+    colours = ["r", "g", "b"]
+    ground_truth_aggregated = {
+        color: canvas.points(ground_truth_data_frame, "x", "y", ds.mean(color))
+        for color in colours
+    }
+    predited_belief_vector_aggregated = {
+        color: canvas.points(
+            predicted_belief_vector_data_frame, "x", "y", ds.mean(color)
+        )
+        for color in colours
+    }
+
+    img_gt = _combine_channels_to_rgb(
+        ground_truth_aggregated["r"],
+        ground_truth_aggregated["g"],
+        ground_truth_aggregated["b"],
+        px=px,
+    )
+    img_pb = _combine_channels_to_rgb(
+        predited_belief_vector_aggregated["r"],
+        predited_belief_vector_aggregated["g"],
+        predited_belief_vector_aggregated["b"],
+        px=px,
+    )
 
     # Visualization with Matplotlib
-    fig, axs = plt.subplots(1, 2, figsize=(10, 5), sharex=True, sharey=True, facecolor=facecolor)
+    fig, axs = plt.subplots(
+        1, 2, figsize=(10, 5), sharex=True, sharey=True, facecolor=facecolor
+    )
     for ax in axs:
-        ax.tick_params(axis='x', colors=facecolor)  
-        ax.tick_params(axis='y', colors=facecolor)  
-        ax.xaxis.label.set_color(facecolor)  
-        ax.yaxis.label.set_color(facecolor)  
+        ax.tick_params(axis="x", colors=facecolor)
+        ax.tick_params(axis="y", colors=facecolor)
+        ax.xaxis.label.set_color(facecolor)
+        ax.yaxis.label.set_color(facecolor)
         ax.title.set_color(facecolor)
     axs[0].imshow(img_gt)
     axs[1].imshow(img_pb)
-    
-    axs[0].axis('off')
-    axs[1].axis('off')
-    title_y_position = -0.1  # Adjust this value to move the title up or down relative to the axes
-    fig.text(0.5, title_y_position, 'Ground Truth', ha='center', va='top', transform=axs[0].transAxes, color='white', fontsize=15)  # Changed 'black' to 'white'
-    fig.text(0.5, title_y_position, 'Residual Stream', ha='center', va='top', transform=axs[1].transAxes, color='white', fontsize=15)  # Changed 'black' to 'white'
+
+    axs[0].axis("off")
+    axs[1].axis("off")
+    title_y_position = (
+        -0.1
+    )  # Adjust this value to move the title up or down relative to the axes
+    fig.text(
+        0.5,
+        title_y_position,
+        "Ground Truth",
+        ha="center",
+        va="top",
+        transform=axs[0].transAxes,
+        color="white",
+        fontsize=15,
+    )  # Changed 'black' to 'white'
+    fig.text(
+        0.5,
+        title_y_position,
+        "Residual Stream",
+        ha="center",
+        va="top",
+        transform=axs[1].transAxes,
+        color="white",
+        fontsize=15,
+    )  # Changed 'black' to 'white'
 
     if plot_triangles:
         for ax in axs:
-            ax.plot([0, 0.5, 1, 0], [0, np.sqrt(3)/2, 0, 0], 'white', lw=2)  # Changed 'black' to 'white'
+            ax.plot(
+                [0, 0.5, 1, 0], [0, np.sqrt(3) / 2, 0, 0], "white", lw=2
+            )  # Changed 'black' to 'white'
 
     return fig
+
 
 if __name__ == "__main__":
     model_config = RawModelConfig(
@@ -101,8 +172,16 @@ if __name__ == "__main__":
         d_mlp=12,
         n_layers=2,
     )
-    model = model_config.to_hooked_transformer(seed=13, device=torch.device('cpu'))
+    model = model_config.to_hooked_transformer(seed=13, device=torch.device("cpu"))
     process = ZeroOneR()
 
-    belief_states_reshaped, predicted_beliefs = find_msp_subspace_in_residual_stream(model=model, process=process, num_sequences=5)
-    plot_ground_truth_and_evaluated_2d_simplex(ground_truth_tensor=belief_states_reshaped, predicted_beliefs=predicted_beliefs, plot_triangles=True, facecolor='black', px=20)
+    belief_states_reshaped, predicted_beliefs = find_msp_subspace_in_residual_stream(
+        model=model, process=process, num_sequences=5
+    )
+    plot_ground_truth_and_evaluated_2d_simplex(
+        ground_truth_tensor=belief_states_reshaped,
+        predicted_beliefs=predicted_beliefs,
+        plot_triangles=True,
+        facecolor="black",
+        px=20,
+    )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,27 +1,36 @@
 import numpy as np
 import pytest
-from transformer_lens import HookedTransformer
-import torch
-from epsilon_transformers.analysis.activation_analysis import find_msp_subspace_in_residual_stream, generate_belief_state_and_activations
+from epsilon_transformers.analysis.activation_analysis import (
+    find_msp_subspace_in_residual_stream,
+    generate_belief_state_and_activations,
+)
 
 from epsilon_transformers.process.processes import ZeroOneR
 from epsilon_transformers.training.configs.model_configs import RawModelConfig
 
+
 def test_msp_path_to_beliefs():
     process = ZeroOneR()
     msp = process.derive_mixed_state_presentation(depth=5)
-    out = msp.path_to_beliefs(path=[0,1,1,0,1])
-    assert np.array_equal(out, np.array([[1/3, 2/3, 0.        ],
-       [0.        , 0.        , 1.        ],
-       [1.        , 0.        , 0.        ],
-       [0.        , 1.        , 0.        ],
-       [0.        , 0.        , 1.        ]]))
-    
-    with pytest.raises(AssertionError):
-        out = msp.path_to_beliefs(path=[0,1,1,0,1,0,0,1,1])
+    out = msp.path_to_beliefs(path=[0, 1, 1, 0, 1])
+    assert np.array_equal(
+        out,
+        np.array(
+            [
+                [1 / 3, 2 / 3, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ),
+    )
 
     with pytest.raises(AssertionError):
-        out = msp.path_to_beliefs(path=[1,1,1])
+        out = msp.path_to_beliefs(path=[0, 1, 1, 0, 1, 0, 0, 1, 1])
+
+    with pytest.raises(AssertionError):
+        out = msp.path_to_beliefs(path=[1, 1, 1])
 
 
 def test_generate_belief_state_and_activations():
@@ -34,15 +43,18 @@ def test_generate_belief_state_and_activations():
         d_mlp=12,
         n_layers=2,
     )
-    model = model_config.to_hooked_transformer(seed=13, device='cpu')
+    model = model_config.to_hooked_transformer(seed=13, device="cpu")
     process = ZeroOneR()
 
-    belief_states, activations = generate_belief_state_and_activations(model=model, process=process, num_sequences=5)
+    belief_states, activations = generate_belief_state_and_activations(
+        model=model, process=process, num_sequences=5
+    )
 
     assert belief_states.shape[0] == activations.shape[0] == 5
     assert belief_states.shape[1] == activations.shape[1] == model.cfg.n_ctx
     assert belief_states.shape[2] == process.num_states
     assert activations.shape[2] == model.cfg.d_model
+
 
 # TODO: Test find_msp_subspace_in_residual_stream (assert rank of predicted beliefs??)
 def test_msp_subspace_in_residual_stream():
@@ -55,14 +67,17 @@ def test_msp_subspace_in_residual_stream():
         d_mlp=12,
         n_layers=2,
     )
-    model = model_config.to_hooked_transformer(seed=13, device='cpu')
+    model = model_config.to_hooked_transformer(seed=13, device="cpu")
     process = ZeroOneR()
 
-    belief_states_reshaped, predicted_beliefs = find_msp_subspace_in_residual_stream(model=model, process=process, num_sequences=5)
+    belief_states_reshaped, predicted_beliefs = find_msp_subspace_in_residual_stream(
+        model=model, process=process, num_sequences=5
+    )
 
     print(belief_states_reshaped.shape)
     print(predicted_beliefs.shape)
-    
+
+
 # TODO: Visualization tests
 # TODO: E2E test w/ training
 if __name__ == "__main__":

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -5,11 +5,16 @@ import pytest
 import torch
 from io import BytesIO
 from dotenv import load_dotenv
-from transformer_lens import HookedTransformer
 import numpy as np
 
 from epsilon_transformers.persistence import LocalPersister, S3Persister
-from epsilon_transformers.training.configs.training_configs import LoggingConfig, OptimizerConfig, PersistanceConfig, ProcessDatasetConfig, TrainConfig
+from epsilon_transformers.training.configs.training_configs import (
+    LoggingConfig,
+    OptimizerConfig,
+    PersistanceConfig,
+    ProcessDatasetConfig,
+    TrainConfig,
+)
 from epsilon_transformers.training.configs.model_configs import RawModelConfig
 from epsilon_transformers.training.train import train_model
 
@@ -22,37 +27,33 @@ from epsilon_transformers.training.train import train_model
 # TODO: Add a reset to the bucket state before running all the tests
 # TODO: Move test non existing bucket into it's own test
 
+
 def test_e2e_training():
-    bucket_name = 'lucas-testing-rrxor-s3-training'
-    s3 = boto3.client('s3')
+    bucket_name = "lucas-testing-rrxor-s3-training"
+    s3 = boto3.client("s3")
     s3.create_bucket(Bucket=bucket_name)
-    
+
     model_config = RawModelConfig(
-            d_vocab=2,
-            d_model=100,
-            n_ctx=10,
-            d_head=48,
-            n_head=12,
-            d_mlp=12,
-            n_layers=2,
-        )
+        d_vocab=2,
+        d_model=100,
+        n_ctx=10,
+        d_head=48,
+        n_head=12,
+        d_mlp=12,
+        n_layers=2,
+    )
     optimizer_config = OptimizerConfig(
-        optimizer_type='adam',
-        learning_rate=1.06e-4,
-        weight_decay=0.8
+        optimizer_type="adam", learning_rate=1.06e-4, weight_decay=0.8
     )
 
     dataset_config = ProcessDatasetConfig(
-        process='rrxor',
-        batch_size=5,
-        num_tokens=500,
-        test_split=0.15
+        process="rrxor", batch_size=5, num_tokens=500, test_split=0.15
     )
 
     persistance_config = PersistanceConfig(
-        location='s3',
-        collection_location= 'lucas-testing-rrxor-s3-training',
-        checkpoint_every_n_tokens=100
+        location="s3",
+        collection_location="lucas-testing-rrxor-s3-training",
+        checkpoint_every_n_tokens=100,
     )
 
     mock_config = TrainConfig(
@@ -60,14 +61,15 @@ def test_e2e_training():
         optimizer=optimizer_config,
         dataset=dataset_config,
         persistance=persistance_config,
-        logging=LoggingConfig(project_name='lucas-testing-rrxor-s3-training', wandb=False),
+        logging=LoggingConfig(
+            project_name="lucas-testing-rrxor-s3-training", wandb=False
+        ),
         verbose=True,
-        seed=1337
+        seed=1337,
     )
     train_model(mock_config)
 
     s3.delete_bucket(Bucket=bucket_name)
-
 
 
 def test_s3_save_model_overwrite_protection():
@@ -79,7 +81,7 @@ def test_s3_save_model_overwrite_protection():
 
         def forward(self, x):
             return self.fc(x)
-        
+
     # Create an instance of the neural network
     network = SimpleNN()
 
@@ -89,16 +91,17 @@ def test_s3_save_model_overwrite_protection():
 
     # Upload the serialized network to the bucket
     load_dotenv()
-    s3 = boto3.client('s3')
-    bucket_name = 'lucas-getting-started-with-s3-demo'
-    
+    s3 = boto3.client("s3")
+    bucket_name = "lucas-getting-started-with-s3-demo"
+
     buffer.seek(0)  # Reset buffer position to the beginning
-    s3.upload_fileobj(buffer, bucket_name, '45.pt')
-    
+    s3.upload_fileobj(buffer, bucket_name, "45.pt")
+
     persister = S3Persister(collection_location=bucket_name)
 
     with pytest.raises(ValueError):
         persister.save_model(network, 45)
+
 
 def load_local_model():
     # Define a simple neural network
@@ -120,8 +123,15 @@ def load_local_model():
         persister = LocalPersister(collection_location=pathlib.Path(temp_dir))
         loaded_model = persister.load_model(model=SimpleNN(), object_name="model.pt")
 
-    assert torch.all(torch.eq(loaded_model.state_dict()['fc.weight'], model.state_dict()['fc.weight']))
-    assert torch.all(torch.eq(loaded_model.state_dict()['fc.bias'], model.state_dict()['fc.bias']))
+    assert torch.all(
+        torch.eq(
+            loaded_model.state_dict()["fc.weight"], model.state_dict()["fc.weight"]
+        )
+    )
+    assert torch.all(
+        torch.eq(loaded_model.state_dict()["fc.bias"], model.state_dict()["fc.bias"])
+    )
+
 
 def save_local_model():
     # Define a simple neural network
@@ -139,73 +149,87 @@ def save_local_model():
     with tempfile.TemporaryDirectory() as temp_dir:
         persister = LocalPersister(collection_location=pathlib.Path(temp_dir))
         num_tokens = 45
-        
+
         persister.save_model(model, num_tokens)
 
         loaded_model = SimpleNN()
         loaded_model_dict = torch.load(pathlib.Path(temp_dir) / f"{num_tokens}.pt")
         loaded_model.load_state_dict(loaded_model_dict)
-    assert torch.all(torch.eq(loaded_model.state_dict()['fc.weight'], model.state_dict()['fc.weight']))
-    assert torch.all(torch.eq(loaded_model.state_dict()['fc.bias'], model.state_dict()['fc.bias']))
+    assert torch.all(
+        torch.eq(
+            loaded_model.state_dict()["fc.weight"], model.state_dict()["fc.weight"]
+        )
+    )
+    assert torch.all(
+        torch.eq(loaded_model.state_dict()["fc.bias"], model.state_dict()["fc.bias"])
+    )
 
 
 def test_save_and_load_s3_model():
-    bucket_name = 'lucas-new-test-bucket-003'
+    bucket_name = "lucas-new-test-bucket-003"
     with pytest.raises(ValueError):
         S3Persister(collection_location=bucket_name)
-    
-    # Create mock bucket
-    s3 = boto3.client('s3')
-    s3.create_bucket(Bucket=bucket_name)
-    
-    persister = S3Persister(collection_location=bucket_name)
-    
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    model = RawModelConfig(
-         d_vocab=3,
-         d_model=64,
-         n_ctx=10,
-         d_head=8,
-         n_head=1,
-         d_mlp=256,
-         n_layers=4,
-     ).to_hooked_transformer(seed=1337, device=device)
 
-    
+    # Create mock bucket
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket=bucket_name)
+
+    persister = S3Persister(collection_location=bucket_name)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = RawModelConfig(
+        d_vocab=3,
+        d_model=64,
+        n_ctx=10,
+        d_head=8,
+        n_head=1,
+        d_mlp=256,
+        n_layers=4,
+    ).to_hooked_transformer(seed=1337, device=device)
+
     # test save
     persister.save_model(model, 85)
 
     download_buffer = BytesIO()
-    s3.download_fileobj(bucket_name, '85.pt', download_buffer)
-    
-    
+    s3.download_fileobj(bucket_name, "85.pt", download_buffer)
+
     def _scramble_weights(model):
         for param in model.parameters():
             with torch.no_grad():
                 if len(param.shape) > 1:  # Only scramble weights, not biases
                     flattened_param = param.view(-1)
-                    np.random.shuffle(flattened_param.numpy())  # Shuffle the flattened weights
+                    np.random.shuffle(
+                        flattened_param.numpy()
+                    )  # Shuffle the flattened weights
                     param.data = flattened_param.view(param.shape)  # Restore the shape
         return model
 
     # Load the downloaded network
-    downloaded_model = _scramble_weights(RawModelConfig(
-         d_vocab=3,
-         d_model=64,
-         n_ctx=10,
-         d_head=8,
-         n_head=1,
-         d_mlp=256,
-         n_layers=4,
-     ).to_hooked_transformer(seed=1337, device=device))
+    downloaded_model = _scramble_weights(
+        RawModelConfig(
+            d_vocab=3,
+            d_model=64,
+            n_ctx=10,
+            d_head=8,
+            n_head=1,
+            d_mlp=256,
+            n_layers=4,
+        ).to_hooked_transformer(seed=1337, device=device)
+    )
     download_buffer.seek(0)  # Reset download buffer position to the beginning
     downloaded_model.load_state_dict(torch.load(download_buffer))
 
     # Assert that the downloaded network is the same as the original one
-    for (name1, param1), (name2, param2) in zip(model.named_parameters(), downloaded_model.named_parameters()):
+    for (name1, param1), (name2, param2) in zip(
+        model.named_parameters(), downloaded_model.named_parameters()
+    ):
         assert name1 == name2, "Model structure mismatch"
-        assert param1.shape == param2.shape, f"Parameter shape mismatch for {name1} and {name2}"
-        assert torch.allclose(param1, param2), f"Parameter values mismatch for {name1} and {name2}"
+        assert (
+            param1.shape == param2.shape
+        ), f"Parameter shape mismatch for {name1} and {name2}"
+        assert torch.allclose(
+            param1, param2
+        ), f"Parameter values mismatch for {name1} and {name2}"
 
     # Test save overwrite protection
     with pytest.raises(ValueError):
@@ -213,14 +237,21 @@ def test_save_and_load_s3_model():
 
     # Test load
     loaded_model = persister.load_model(device=device, object_name="85.pt")
-    for (name1, param1), (name2, param2) in zip(model.named_parameters(), loaded_model.named_parameters()):
+    for (name1, param1), (name2, param2) in zip(
+        model.named_parameters(), loaded_model.named_parameters()
+    ):
         assert name1 == name2, "Model structure mismatch"
-        assert param1.shape == param2.shape, f"Parameter shape mismatch for {name1} and {name2}"
-        assert torch.allclose(param1, param2), f"Parameter values mismatch for {name1} and {name2}"
-       
+        assert (
+            param1.shape == param2.shape
+        ), f"Parameter shape mismatch for {name1} and {name2}"
+        assert torch.allclose(
+            param1, param2
+        ), f"Parameter values mismatch for {name1} and {name2}"
+
     # Delete mock bucket
-    s3.delete_object(Bucket=bucket_name, Key='85.pt')
+    s3.delete_object(Bucket=bucket_name, Key="85.pt")
     s3.delete_bucket(Bucket=bucket_name)
+
 
 def test_s3_persistence_put_and_retrieve_object_from_bucket():
     # Define a simple neural network
@@ -241,14 +272,14 @@ def test_s3_persistence_put_and_retrieve_object_from_bucket():
 
     # Upload the serialized network to the bucket
     load_dotenv()
-    s3 = boto3.client('s3')
-    bucket_name = 'lucas-getting-started-with-s3-demo'
+    s3 = boto3.client("s3")
+    bucket_name = "lucas-getting-started-with-s3-demo"
     buffer.seek(0)  # Reset buffer position to the beginning
-    s3.upload_fileobj(buffer, bucket_name, 'model.pt')
+    s3.upload_fileobj(buffer, bucket_name, "model.pt")
 
     # Download the serialized network from the bucket
     download_buffer = BytesIO()
-    s3.download_fileobj(bucket_name, 'model.pt', download_buffer)
+    s3.download_fileobj(bucket_name, "model.pt", download_buffer)
 
     # Load the downloaded network
     downloaded_network = SimpleNN()
@@ -256,10 +287,19 @@ def test_s3_persistence_put_and_retrieve_object_from_bucket():
     downloaded_network.load_state_dict(torch.load(download_buffer))
 
     # Assert that the downloaded network is the same as the original one
-    assert torch.all(torch.eq(network.state_dict()['fc.weight'], downloaded_network.state_dict()['fc.weight']))
-    assert torch.all(torch.eq(network.state_dict()['fc.bias'], downloaded_network.state_dict()['fc.bias']))
+    assert torch.all(
+        torch.eq(
+            network.state_dict()["fc.weight"],
+            downloaded_network.state_dict()["fc.weight"],
+        )
+    )
+    assert torch.all(
+        torch.eq(
+            network.state_dict()["fc.bias"], downloaded_network.state_dict()["fc.bias"]
+        )
+    )
 
-    s3.delete_object(Bucket=bucket_name, Key='model.pt')
+    s3.delete_object(Bucket=bucket_name, Key="model.pt")
 
 
 def test_s3_create_and_delete_bucket():
@@ -280,17 +320,17 @@ def test_s3_create_and_delete_bucket():
     torch.save(network.state_dict(), buffer)
 
     # Create a new S3 bucket
-    s3 = boto3.client('s3')
-    bucket_name = 'lucas-new-test-bucket-003'
+    s3 = boto3.client("s3")
+    bucket_name = "lucas-new-test-bucket-003"
     s3.create_bucket(Bucket=bucket_name)
 
     # Upload the serialized network to the bucket
     buffer.seek(0)  # Reset buffer position to the beginning
-    s3.upload_fileobj(buffer, bucket_name, 'model.pt')
+    s3.upload_fileobj(buffer, bucket_name, "model.pt")
 
     # Download the serialized network from the bucket
     download_buffer = BytesIO()
-    s3.download_fileobj(bucket_name, 'model.pt', download_buffer)
+    s3.download_fileobj(bucket_name, "model.pt", download_buffer)
 
     # Load the downloaded network
     downloaded_network = SimpleNN()
@@ -298,17 +338,27 @@ def test_s3_create_and_delete_bucket():
     downloaded_network.load_state_dict(torch.load(download_buffer))
 
     # Assert that the downloaded network is the same as the original one
-    assert torch.all(torch.eq(network.state_dict()['fc.weight'], downloaded_network.state_dict()['fc.weight']))
-    assert torch.all(torch.eq(network.state_dict()['fc.bias'], downloaded_network.state_dict()['fc.bias']))
+    assert torch.all(
+        torch.eq(
+            network.state_dict()["fc.weight"],
+            downloaded_network.state_dict()["fc.weight"],
+        )
+    )
+    assert torch.all(
+        torch.eq(
+            network.state_dict()["fc.bias"], downloaded_network.state_dict()["fc.bias"]
+        )
+    )
 
     # Clean up: delete the file and the bucket
-    s3.delete_object(Bucket=bucket_name, Key='model.pt')
+    s3.delete_object(Bucket=bucket_name, Key="model.pt")
     s3.delete_bucket(Bucket=bucket_name)
 
     # Assert that the bucket was deleted
     response = s3.list_buckets()
-    bucket_names = [bucket['Name'] for bucket in response['Buckets']]
+    bucket_names = [bucket["Name"] for bucket in response["Buckets"]]
     assert bucket_name not in bucket_names, f"Bucket {bucket_name} was not deleted"
+
 
 if __name__ == "__main__":
     test_save_and_load_s3_model()

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,12 +1,14 @@
-from typing import List, Set, Tuple
+from typing import List, Tuple
 import pytest
 from torch.utils.data import DataLoader
 import numpy as np
 
-from epsilon_transformers.process.MixedStateTree import MixedStateTreeNode
 from epsilon_transformers.process.Process import ProcessHistory
 from epsilon_transformers.process.processes import ZeroOneR
-from epsilon_transformers.process.dataset import ProcessDataset, process_dataset_collate_fn
+from epsilon_transformers.process.dataset import (
+    ProcessDataset,
+    process_dataset_collate_fn,
+)
 
 # TODO: Check for off by 1 error in the sample_emission asserts
 # TODO: Check that histogram distribution matches steady state distribution in test_generate_single_sequence
@@ -14,6 +16,7 @@ from epsilon_transformers.process.dataset import ProcessDataset, process_dataset
 # TODO: parameterize this for each process
 # TODO: parameterize current_state_index
 # TODO: Parameterize number of sequences & sequence lengths
+
 
 def test_sample_emission():
     process = ZeroOneR()
@@ -28,6 +31,7 @@ def test_sample_emission():
     emission = process._sample_emission(current_state_index)
     assert 0 <= emission <= process.vocab_len
 
+
 def test_generate_process_history():
     process = ZeroOneR()
 
@@ -35,19 +39,23 @@ def test_generate_process_history():
     assert len(outs) == 12
     assert isinstance(outs, ProcessHistory)
 
+
 def test_process_dataset():
-    dataset = ProcessDataset('z1r', 10, 15)
-    
+    dataset = ProcessDataset("z1r", 10, 15)
+
     for data, label in dataset:
         assert len(data) == len(label) == 10
         assert data[1:] == label[:-1]
 
-    dataset = ProcessDataset('z1r', 10, 16)
-    dataloader = DataLoader(dataset=dataset, collate_fn=process_dataset_collate_fn, batch_size=2)
+    dataset = ProcessDataset("z1r", 10, 16)
+    dataloader = DataLoader(
+        dataset=dataset, collate_fn=process_dataset_collate_fn, batch_size=2
+    )
 
     for data, label in dataloader:
         assert len(data) == len(label) == 2  # Since batch_size is set to 2
         assert (data[:, 1:] == label[:, :-1]).all()
+
 
 def test_yield_emission_histories():
     process = ZeroOneR()
@@ -59,27 +67,51 @@ def test_yield_emission_histories():
     assert len(out) == 3
     assert out[0] != out[1] != out[2]
 
+
 def test_compute_emission_probabilities():
     return NotImplementedError
+
 
 def test_compute_next_distribution():
     return NotImplementedError
 
+
 def test_msp_creation():
     process = ZeroOneR()
     z1r_msp = process.derive_mixed_state_presentation(depth=5)
-    paths_and_probs = sorted([(x.path, x.state_prob_vector) for x in z1r_msp.nodes], key=lambda x: len(x[0]))
-    assert paths_and_probs[0][0] == [] and np.array_equal(paths_and_probs[0][1], np.array([1/3, 1/3, 1/3]))
+    paths_and_probs = sorted(
+        [(x.path, x.state_prob_vector) for x in z1r_msp.nodes], key=lambda x: len(x[0])
+    )
+    assert paths_and_probs[0][0] == [] and np.array_equal(
+        paths_and_probs[0][1], np.array([1 / 3, 1 / 3, 1 / 3])
+    )
+
     def _query_path(list_of_tuples, path: list) -> Tuple[List[int], np.ndarray]:
         for tup in list_of_tuples:
             if path == tup[0]:
                 return tup
         raise ValueError(f"{path} not in list of tuples")
-    assert np.array_equal(_query_path(paths_and_probs, [])[1], np.array([1/3, 1/3, 1/3]))
-    assert np.array_equal(_query_path(paths_and_probs, [0])[1], np.array([1/3, 2/3, 0]))
-    assert np.array_equal(_query_path(paths_and_probs, [1])[1], np.array([1/3, 0, 2/3]))
-    assert np.array_equal(_query_path(paths_and_probs, [1, 0])[1], np.array([1/2, 1/2, 0]))
-    assert all([np.all((vector == 0) | (vector == 1)) and np.sum(vector) == 1 for path, vector in paths_and_probs if path != [] and path != [0] and path != [1] and path != [1,0]])
+
+    assert np.array_equal(
+        _query_path(paths_and_probs, [])[1], np.array([1 / 3, 1 / 3, 1 / 3])
+    )
+    assert np.array_equal(
+        _query_path(paths_and_probs, [0])[1], np.array([1 / 3, 2 / 3, 0])
+    )
+    assert np.array_equal(
+        _query_path(paths_and_probs, [1])[1], np.array([1 / 3, 0, 2 / 3])
+    )
+    assert np.array_equal(
+        _query_path(paths_and_probs, [1, 0])[1], np.array([1 / 2, 1 / 2, 0])
+    )
+    assert all(
+        [
+            np.all((vector == 0) | (vector == 1)) and np.sum(vector) == 1
+            for path, vector in paths_and_probs
+            if path != [] and path != [0] and path != [1] and path != [1, 0]
+        ]
+    )
+
 
 if __name__ == "__main__":
     test_yield_emission_histories()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,10 +5,23 @@ from torch.utils.data import DataLoader
 from transformer_lens import HookedTransformer
 import tempfile
 
-from epsilon_transformers.process.dataset import ProcessDataset, process_dataset_collate_fn
-from epsilon_transformers.training.configs.training_configs import TrainConfig, OptimizerConfig, ProcessDatasetConfig, PersistanceConfig, LoggingConfig
+from epsilon_transformers.process.dataset import (
+    ProcessDataset,
+    process_dataset_collate_fn,
+)
+from epsilon_transformers.training.configs.training_configs import (
+    TrainConfig,
+    OptimizerConfig,
+    ProcessDatasetConfig,
+    PersistanceConfig,
+    LoggingConfig,
+)
 from epsilon_transformers.training.configs.model_configs import RawModelConfig
-from epsilon_transformers.training.train import train_model, _check_if_action_batch, _set_random_seed
+from epsilon_transformers.training.train import (
+    train_model,
+    _check_if_action_batch,
+    _set_random_seed,
+)
 
 # TODO: Paramaterize test_configs_throw_error_on_extra
 # TODO: Patamaterize train_model w/ all configs
@@ -17,9 +30,16 @@ from epsilon_transformers.training.train import train_model, _check_if_action_ba
 # TODO: Test for writing multiple checkpoints
 # TODO: Write test to make sure transformer is initialized correctly
 
+
 def test_configs_throw_error_on_extra():
     with pytest.raises(ValidationError):
-        OptimizerConfig(optimizer_type='adam', learning_rate=1.06e-12, weight_decay=.08, jungle_bunny='hoorah')
+        OptimizerConfig(
+            optimizer_type="adam",
+            learning_rate=1.06e-12,
+            weight_decay=0.08,
+            jungle_bunny="hoorah",
+        )
+
 
 def test_raw_model_config():
     model_config = RawModelConfig(
@@ -31,11 +51,14 @@ def test_raw_model_config():
         d_mlp=12,
         n_layers=2,
     )
-    model = model_config.to_hooked_transformer(seed=13, device='cpu')
+    model = model_config.to_hooked_transformer(seed=13, device="cpu")
     assert isinstance(model, HookedTransformer)
-    input_tensor = torch.tensor([[0,1,0,1,1,0]], device='cpu', dtype=torch.long)
+    input_tensor = torch.tensor([[0, 1, 0, 1, 1, 0]], device="cpu", dtype=torch.long)
     output = model(input_tensor)
-    assert output.shape == torch.Size([1,6,2]) # batch, pos, vocab (it returns logits)
+    assert output.shape == torch.Size(
+        [1, 6, 2]
+    )  # batch, pos, vocab (it returns logits)
+
 
 def test_dataloader_raw_hooked_transformer_compatibility():
     model_config = RawModelConfig(
@@ -47,32 +70,57 @@ def test_dataloader_raw_hooked_transformer_compatibility():
         d_mlp=12,
         n_layers=2,
     )
-    model = model_config.to_hooked_transformer(seed=13, device='cpu')
-    
-    dataset = ProcessDataset('z1r', 10, 16)
-    dataloader = DataLoader(dataset=dataset, collate_fn=process_dataset_collate_fn, batch_size=2)
+    model = model_config.to_hooked_transformer(seed=13, device="cpu")
 
-    for x, _  in dataloader:
+    dataset = ProcessDataset("z1r", 10, 16)
+    dataloader = DataLoader(
+        dataset=dataset, collate_fn=process_dataset_collate_fn, batch_size=2
+    )
+
+    for x, _ in dataloader:
         output = model(x)
-        assert output.shape == torch.Size([1,10,2]) # batch, pos, vocab (it returns logits)
+        assert output.shape == torch.Size(
+            [1, 10, 2]
+        )  # batch, pos, vocab (it returns logits)
+
 
 def test_check_if_action_batch():
-    assert _check_if_action_batch(perform_action_every_n_tokens=100, batch_size=5, sequence_len=10, batch_idx=1) == True
-    assert _check_if_action_batch(perform_action_every_n_tokens=100, batch_size=5, sequence_len=10, batch_idx=2) == False
+    assert (
+        _check_if_action_batch(
+            perform_action_every_n_tokens=100,
+            batch_size=5,
+            sequence_len=10,
+            batch_idx=1,
+        )
+        == True
+    )
+    assert (
+        _check_if_action_batch(
+            perform_action_every_n_tokens=100,
+            batch_size=5,
+            sequence_len=10,
+            batch_idx=2,
+        )
+        == False
+    )
     with pytest.raises(AssertionError):
-        _check_if_action_batch(perform_action_every_n_tokens=5, batch_size=2, sequence_len=10, batch_idx=4)
+        _check_if_action_batch(
+            perform_action_every_n_tokens=5, batch_size=2, sequence_len=10, batch_idx=4
+        )
+
 
 def test_train_and_test_dataloaders_are_different():
     _set_random_seed(45)
 
-    config = ProcessDatasetConfig(process='z1r', batch_size=2, num_tokens=100)
+    config = ProcessDatasetConfig(process="z1r", batch_size=2, num_tokens=100)
     train_dataloader = config.to_dataloader(sequence_length=10)
     test_dataloader = config.to_dataloader(sequence_length=10)
-    
+
     train_data = [x for x, _ in train_dataloader]
     test_data = [x for x, _ in test_dataloader]
 
-    assert all([not torch.equal(x, y) for x,y in zip(train_data, test_data)])
+    assert all([not torch.equal(x, y) for x, y in zip(train_data, test_data)])
+
 
 def test_persistance():
     class LinearModel(torch.nn.Module):
@@ -85,22 +133,34 @@ def test_persistance():
 
     model = LinearModel()
     with tempfile.TemporaryDirectory() as temp_dir:
-        config = PersistanceConfig(location='local', collection_location=temp_dir, checkpoint_every_n_tokens=100)
+        config = PersistanceConfig(
+            location="local",
+            collection_location=temp_dir,
+            checkpoint_every_n_tokens=100,
+        )
         config.save_model(model, 55)
 
         loaded_model = LinearModel()
         loaded_model.fc.weight.data.fill_(1.0)
         loaded_model.fc.bias.data.fill_(0.0)
-        assert any(not torch.equal(p1, p2) for p1, p2 in zip(model.parameters(), loaded_model.parameters()))
-        
+        assert any(
+            not torch.equal(p1, p2)
+            for p1, p2 in zip(model.parameters(), loaded_model.parameters())
+        )
+
         loaded_model.load_state_dict(torch.load(f"{temp_dir}/55.pt"))
 
-    assert all(torch.equal(p1, p2) for p1, p2 in zip(model.parameters(), loaded_model.parameters()))
+    assert all(
+        torch.equal(p1, p2)
+        for p1, p2 in zip(model.parameters(), loaded_model.parameters())
+    )
+
 
 def test_changing_log_states():
     # Input numbers make sense
-    # 
+    #
     raise NotImplementedError
+
 
 def test_train_model_config_validator():
     with pytest.raises(ValueError):
@@ -116,22 +176,17 @@ def test_train_model_config_validator():
             )
 
             optimizer_config = OptimizerConfig(
-                optimizer_type='adam',
-                learning_rate=1.06e-4,
-                weight_decay=0.8
+                optimizer_type="adam", learning_rate=1.06e-4, weight_decay=0.8
             )
 
             dataset_config = ProcessDatasetConfig(
-                process='mess3',
-                batch_size=5,
-                num_tokens=500,
-                test_split=0.15
+                process="mess3", batch_size=5, num_tokens=500, test_split=0.15
             )
 
             persistance_config = PersistanceConfig(
-                location='local',
+                location="local",
                 collection_location=temp_dir,
-                checkpoint_every_n_tokens=100
+                checkpoint_every_n_tokens=100,
             )
 
             TrainConfig(
@@ -139,10 +194,13 @@ def test_train_model_config_validator():
                 optimizer=optimizer_config,
                 dataset=dataset_config,
                 persistance=persistance_config,
-                logging=LoggingConfig(project_name="testing-logging-output", wandb=False),
+                logging=LoggingConfig(
+                    project_name="testing-logging-output", wandb=False
+                ),
                 verbose=True,
-                seed=1337
+                seed=1337,
             )
+
 
 def test_train_model():
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -157,22 +215,17 @@ def test_train_model():
         )
 
         optimizer_config = OptimizerConfig(
-            optimizer_type='adam',
-            learning_rate=1.06e-4,
-            weight_decay=0.8
+            optimizer_type="adam", learning_rate=1.06e-4, weight_decay=0.8
         )
 
         dataset_config = ProcessDatasetConfig(
-            process='rrxor',
-            batch_size=5,
-            num_tokens=500,
-            test_split=0.15
+            process="rrxor", batch_size=5, num_tokens=500, test_split=0.15
         )
 
         persistance_config = PersistanceConfig(
-            location='local',
+            location="local",
             collection_location=temp_dir,
-            checkpoint_every_n_tokens=100
+            checkpoint_every_n_tokens=100,
         )
 
         mock_config = TrainConfig(
@@ -182,11 +235,12 @@ def test_train_model():
             persistance=persistance_config,
             logging=LoggingConfig(project_name="testing-logging-output", wandb=False),
             verbose=True,
-            seed=1337
+            seed=1337,
         )
         model, metrics = train_model(mock_config)
 
         # Assert that the loss has decreased
+
 
 if __name__ == "__main__":
     test_train_model()


### PR DESCRIPTION
Some imports seem to be leftover from past iterations. These clutter the code and slow down the execution of the project. Also applied the default formatter (black) to the project files, including the tests.